### PR TITLE
Remove return from authenticate docstring

### DIFF
--- a/hey/middlewares/mindsdb.py
+++ b/hey/middlewares/mindsdb.py
@@ -45,8 +45,6 @@ class MindsDB:
     def authenticate(self) -> None:
         """
         authorizes the email and password with MindsDB's host
-        Returns:
-            server object
         """
 
         try:


### PR DESCRIPTION
Since this function doesn't return anything, maybe we can remove this part.